### PR TITLE
Remove NumPy dependency

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Debajyoti Nandi
+Copyright (c) 2021 Hagai Helman Tov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,16 @@ and :math:`M` union/find operations. The function :math:`\log^*` is the number
 of times needed to take :math:`\log` (base 2) of a number until reaching 1. In
 practice, the amortized cost of each operation is nearly linear [1]_.
 
+Installation With `pip`
+---------------------
+
+```bash
+pip install pyunionfind
+```
+
+This installs a module named `unionfind`.
+
+
 Contents
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -9,19 +9,19 @@ to the same component).
 This implements the "weighted-quick-union-with-path-compression" union-find
 algorithm.  Only works if elements are immutable objects.
 
-Worst case for union and find :math:`(N + M \log^* N)`, with :math:`N` elements
-and :math:`M` union/find operations. The function :math:`\log^*` is the number
-of times needed to take :math:`\log` (base 2) of a number until reaching 1. In
+Worst case for union and find ``(N + M log* N)``, with ``N`` elements
+and ``M`` union/find operations. The function ``log*`` is the number
+of times needed to take ``log`` (base 2) of a number until reaching 1. In
 practice, the amortized cost of each operation is nearly linear [1]_.
 
-Installation With `pip`
----------------------
+Installation With ``pip``
+-------------------------
 
-```bash
-pip install pyunionfind
-```
+.. code-block:: sh
 
-This installs a module named `unionfind`.
+        pip install pyunionfind
+
+This installs a module named ``unionfind``.
 
 
 Contents

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,6 @@ Contents
 
 * License: MIT.
 
-Requirements
-------------
-
-* ``numpy``
 
 
 .. [1] http://algs4.cs.princeton.edu/lectures/

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,0 @@
-"""
-UnionFind disjoint sets data structure.
-"""
-
-from . import unionfind

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,12 @@
 [metadata]
 name = pyunionfind
-version = 1.0.0
+version = 1.0.1
 author = Debajyoti Nandi, Hagai Helman Tov
 maintainer = Hagai Helman Tov
 maintainer_email = hagai.helman@gmail.com
 description = A union-find disjoint sets data structure
-long_description = file: README.md
-long_description_content_type = text/markdown
+long_description = file: README.rst
+long_description_content_type = text/x-rst
 url = https://github.com/hagai-helman/unionfind
 license='MIT',
 classifiers = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,25 @@
+[metadata]
+name = pyunionfind
+version = 1.0.0
+author = Debajyoti Nandi, Hagai Helman Tov
+maintainer = Hagai Helman Tov
+maintainer_email = hagai.helman@gmail.com
+description = A union-find disjoint sets data structure
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/hagai-helman/unionfind
+license='MIT',
+classifiers = 
+	Development Status :: 5 - Production/Stable
+	License :: OSI Approved :: MIT License
+	Intended Audience :: Developers
+	Intended Audience :: Science/Research
+	Programming Language :: Python
+	Programming Language :: Python :: 2
+	Programming Language :: Python :: 3
+	Topic :: Scientific/Engineering
+	Topic :: Scientific/Engineering :: Mathematics
+
+[options]
+py_modules = 
+	unionfind

--- a/unionfind.py
+++ b/unionfind.py
@@ -8,6 +8,8 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals,
 )
 
+__all__ = ["UnionFind"]
+
 class UnionFind(object):
     """Union-find disjoint sets datastructure.
 

--- a/unionfind.py
+++ b/unionfind.py
@@ -8,10 +8,6 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals,
 )
 
-# Third-party libraries
-import numpy as np
-
-
 class UnionFind(object):
     """Union-find disjoint sets datastructure.
 
@@ -244,10 +240,8 @@ class UnionFind(object):
         """
         if x not in self:
             raise ValueError('{} is not an element'.format(x))
-        elts = np.array(self._elts)
-        vfind = np.vectorize(self.find)
-        roots = vfind(elts)
-        return set(elts[roots == self.find(x)])
+        root = self.find(x)
+        return set((elt for elt in self._elts if self.find(elt) == root))
 
     def components(self):
         """Return the list of connected components.
@@ -258,17 +252,11 @@ class UnionFind(object):
             A list of sets.
 
         """
-        elts = np.array(self._elts)
-        vfind = np.vectorize(self.find)
-        roots = vfind(elts)
-        distinct_roots = set(roots)
-        return [set(elts[roots == root]) for root in distinct_roots]
-        # comps = []
-        # for root in distinct_roots:
-        #     mask = (roots == root)
-        #     comp = set(elts[mask])
-        #     comps.append(comp)
-        # return comps
+        components_dict = {}
+        for elt in self._elts:
+            root = self.find(elt)
+            components_dict.setdefault(root, set()).add(elt)
+        return list(components_dict.values())
 
     def component_mapping(self):
         """Return a dict mapping elements to their components.
@@ -315,17 +303,11 @@ class UnionFind(object):
             A dict with the semantics: `elt -> component contianing elt`.
 
         """
-        elts = np.array(self._elts)
-        vfind = np.vectorize(self.find)
-        roots = vfind(elts)
-        distinct_roots = set(roots)
-        comps = {}
-        for root in distinct_roots:
-            mask = (roots == root)
-            comp = set(elts[mask])
-            comps.update({x: comp for x in comp})
-            # Change ^this^, if you want a different behaviour:
-            # If you don't want to share the same set to different keys:
-            # comps.update({x: set(comp) for x in comp})
-        return comps
+        components_dict = {}
+        mapping = {}
+        for elt in self._elts:
+            root = self.find(elt)
+            components_dict.setdefault(root, set()).add(elt)
+            mapping[elt] = components_dict[root]
+        return mapping
 


### PR DESCRIPTION
This change:
- Fixes bugs that used to occur when `UnionFind` items were tuples (Fixes #3);
- Asymptotically speeds up the `UnionFind.componenets` method (Fixes #2);
- Makes the module self-contained.